### PR TITLE
fix version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ steps:
     depends_on: my-test
     allow_dependency_failure: true
     plugins:
-      - iress/junit-slack-notification#v1.0.6:
+      - iress/junit-slack-notification#v1.0.8:
           artifacts: "**/*.xml"
           SLACK_TOKEN: "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx"
           SLACK_CHANNEL: "#junit_bot_testing"
@@ -38,7 +38,7 @@ steps:
     depends_on: my-test
     allow_dependency_failure: true
     plugins:
-      - iress/junit-slack-notification#v1.0.6:
+      - iress/junit-slack-notification#v1.0.8:
           test_suites:
               - name: "Unit tests"
                 artifacts: "unit-test/**/*.xml"


### PR DESCRIPTION
fixing https://github.com/iress/junit-slack-notification-buildkite-plugin/actions/runs/15613373880/job/43979718135

```
not ok 3 - Readme version numbers out of date. Latest is v1.0.8
  ---
  outdated version numbers:
    - v1.0.6
    - v1.0.6
  ...
```